### PR TITLE
Fix RandomWrangler crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /dist
 /plugin.so
 /plugin.dylib
+/plugin-arm64.dylib
 /plugin.dll
 .DS_Store

--- a/src/randomwrangler.cpp
+++ b/src/randomwrangler.cpp
@@ -63,7 +63,7 @@ struct RANDOMWRANGLER : TinyTricksModule {
 
   int tick = 0;
 
-  CurveWidget *curve;
+  CurveWidget *curve{nullptr};
 
   std::vector<float> tmp;
 
@@ -79,7 +79,7 @@ struct RANDOMWRANGLER : TinyTricksModule {
 
     configParam(RANDOMWRANGLER::RATE_PARAM, RATE_MIN, RATE_MAX, RATE_MAX, "Rate");
     configParam(RANDOMWRANGLER::SMOOTH_RATE_PARAM, SMOOTH_RATE_MIN, SMOOTH_RATE_MAX, SMOOTH_RATE_MIN, "Smoothing amount");
-    configParam(RANDOMWRANGLER::LIN_SMOOTH_PARAM, 0.0f, 1.0f, 1.0f, "Smooth shape", {"Exponential", "Linear"});
+    configSwitch(RANDOMWRANGLER::LIN_SMOOTH_PARAM, 0.0f, 1.0f, 1.0f, "Smooth shape", {"Exponential", "Linear"});
     // ENUMS(CURVE_CV_INPUT, NUM_CURVE_POINTS),
     configInput(TRIG_INPUT, "Trigger");
     configInput(RATE_CV_INPUT, "Rate CV");
@@ -123,7 +123,8 @@ struct RANDOMWRANGLER : TinyTricksModule {
     json_t *isLiniearModeJ = json_object_get(rootJ, "isLiniearMode");
     if (isLiniearModeJ)
       isLiniearMode = json_is_true(isLiniearModeJ);
-    curve->setMode(isLiniearMode);
+    if (curve)
+      curve->setMode(isLiniearMode);
     //processCurveParams(true);
   }
 


### PR DESCRIPTION
1. Update configParam to the intended configSwitch
2. In dataFromJSON check for null curve widget
3. Add a .gitignore entry for ARM64 builds. Also it seems to compile just fine on ARM64

Closes #24, #27